### PR TITLE
fixed typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Courseware Development Kit (CDK)
 
 .. image:: https://travis-ci.org/twitter/cdk.png?branch=master
     :target: https://travis-ci.org/twitter/cdk
-                    
+
 Use CDK to write documents in `AsciiDoc <http://www.methods.co.nz/asciidoc/>`_ and produce elegant single-file slidedecks as html.
 
 Please see the docs at http://cdk.readthedocs.org/en/latest/
@@ -13,24 +13,24 @@ Installation & Usage
 
 ::
 
-    sudo pip cdk # if you don't have pip try sudo easy_install cdk
+    sudo pip install cdk # if you don't have pip try sudo easy_install cdk
     cdk --generate=sample.asc # generate a sample presentation
     cdk sample.asc  # compile it to html
     open sample.html # use a browser
 
-Contact 
--------- 
+Contact
+--------
 
-In the remote possibility that there exist bugs in this code, please report them to: 
+In the remote possibility that there exist bugs in this code, please report them to:
 https://github.com/twitter/cdk/issues
 
-Authors 
--------- 
+Authors
+--------
 
 * Simeon Franklin (@simeonfranklin)
 
-License 
--------- 
+License
+--------
 
 Copyright 2013 Twitter, Inc and other contributors
 


### PR DESCRIPTION
pip needs a verb, so I changed this.  I also clobbered all trailing whitespace, which I'm happy to remove if you want.
