### PR TITLE
Reorder --open and --toc.

### DIFF
--- a/cdk/__init__.py
+++ b/cdk/__init__.py
@@ -219,11 +219,12 @@ def main():
         run_command(cmd, args)
         if args['--custom-css']:
             add_css_filename(args['--custom-css'], out)
-        if args['--open']:
-            webbrowser.open("file://" + abspath(out))
         if args['--toc']:
             add_css(open(out, "r+"),
                     '.deck-container .deck-toc li a span{color: #888;display:inline;}')
+        if args['--open']:
+            webbrowser.open("file://" + abspath(out))
+
     # other commands
     elif args['--generate']:
         if isfile(args['--generate']):


### PR DESCRIPTION
Seems like a better order so if both options are passed the extra CSS is added before the file is opened.
